### PR TITLE
Updated days generation field

### DIFF
--- a/src/main/java/za/co/dearx/leave/domain/LeaveApplication.java
+++ b/src/main/java/za/co/dearx/leave/domain/LeaveApplication.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.io.Serializable;
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.Period;
 import java.time.ZonedDateTime;
 import javax.persistence.*;
 import javax.validation.constraints.*;
@@ -86,12 +87,13 @@ public class LeaveApplication implements Serializable {
     }
 
     public LeaveApplication startDate(LocalDate startDate) {
-        this.startDate = startDate;
+        setStartDate(startDate);
         return this;
     }
 
     public void setStartDate(LocalDate startDate) {
         this.startDate = startDate;
+        calculateDays();
     }
 
     public LocalDate getEndDate() {
@@ -99,12 +101,13 @@ public class LeaveApplication implements Serializable {
     }
 
     public LeaveApplication endDate(LocalDate endDate) {
-        this.endDate = endDate;
+        setEndDate(endDate);
         return this;
     }
 
     public void setEndDate(LocalDate endDate) {
         this.endDate = endDate;
+        calculateDays();
     }
 
     public ZonedDateTime getAppliedDate() {
@@ -138,12 +141,27 @@ public class LeaveApplication implements Serializable {
     }
 
     public LeaveApplication days(BigDecimal days) {
-        this.days = days;
+        setDays(days);
         return this;
     }
 
+    /**
+     * Calling this method has no effect.
+     * This value is set using {@link #setStartDate(LocalDate)} and/or {@link #setEndDate(LocalDate)}.
+     *
+     * @param days
+     */
     public void setDays(BigDecimal days) {
-        this.days = days;
+        //Do not allow direct setting.
+    }
+
+    private void calculateDays() {
+        if (startDate != null && endDate != null) {
+            Period difference = Period.between(startDate, endDate);
+            this.days = BigDecimal.valueOf(difference.getDays());
+        } else {
+            days = null;
+        }
     }
 
     public Boolean getDeleted() {

--- a/src/main/java/za/co/dearx/leave/service/LeaveApplicationService.java
+++ b/src/main/java/za/co/dearx/leave/service/LeaveApplicationService.java
@@ -1,5 +1,7 @@
 package za.co.dearx.leave.service;
 
+import java.math.BigDecimal;
+import java.time.Period;
 import java.util.Optional;
 import javax.validation.Valid;
 import org.camunda.bpm.engine.RuntimeService;
@@ -81,6 +83,7 @@ public class LeaveApplicationService {
             }
         }
 
+        leaveApplication = this.setLeaveDays(leaveApplication);
         leaveApplication = leaveApplicationRepository.save(leaveApplication);
 
         //When mapping a new LeaveApplication the LeaveType will not be fully set. Retrieve full record
@@ -117,7 +120,7 @@ public class LeaveApplicationService {
                 }
             }
         }
-
+        leaveApplication = this.setLeaveDays(leaveApplication);
         leaveApplication = leaveApplicationRepository.save(leaveApplication);
 
         //Start a new business process, if defined
@@ -256,5 +259,16 @@ public class LeaveApplicationService {
                     }
                 }
             );
+    }
+
+    /**
+     * Calculate number of days applied
+     *
+     * @param leave application entity
+     */
+    private LeaveApplication setLeaveDays(LeaveApplication leaveApplication) {
+        Period difference = Period.between(leaveApplication.getStartDate(), leaveApplication.getEndDate());
+        leaveApplication.days(BigDecimal.valueOf(difference.getDays()));
+        return leaveApplication;
     }
 }

--- a/src/main/java/za/co/dearx/leave/service/LeaveApplicationService.java
+++ b/src/main/java/za/co/dearx/leave/service/LeaveApplicationService.java
@@ -83,7 +83,6 @@ public class LeaveApplicationService {
             }
         }
 
-        leaveApplication = this.setLeaveDays(leaveApplication);
         leaveApplication = leaveApplicationRepository.save(leaveApplication);
 
         //When mapping a new LeaveApplication the LeaveType will not be fully set. Retrieve full record
@@ -120,7 +119,6 @@ public class LeaveApplicationService {
                 }
             }
         }
-        leaveApplication = this.setLeaveDays(leaveApplication);
         leaveApplication = leaveApplicationRepository.save(leaveApplication);
 
         //Start a new business process, if defined
@@ -259,16 +257,5 @@ public class LeaveApplicationService {
                     }
                 }
             );
-    }
-
-    /**
-     * Calculate number of days applied
-     *
-     * @param leave application entity
-     */
-    private LeaveApplication setLeaveDays(LeaveApplication leaveApplication) {
-        Period difference = Period.between(leaveApplication.getStartDate(), leaveApplication.getEndDate());
-        leaveApplication.days(BigDecimal.valueOf(difference.getDays()));
-        return leaveApplication;
     }
 }

--- a/src/main/java/za/co/dearx/leave/service/dto/LeaveApplicationDTO.java
+++ b/src/main/java/za/co/dearx/leave/service/dto/LeaveApplicationDTO.java
@@ -28,7 +28,6 @@ public class LeaveApplicationDTO implements Serializable {
 
     private ZonedDateTime updateDate;
 
-    @NotNull
     private BigDecimal days;
 
     @NotNull

--- a/src/main/java/za/co/dearx/leave/service/mapper/LeaveApplicationMapper.java
+++ b/src/main/java/za/co/dearx/leave/service/mapper/LeaveApplicationMapper.java
@@ -18,4 +18,12 @@ public interface LeaveApplicationMapper extends EntityMapper<LeaveApplicationDTO
     @BeanMapping(ignoreByDefault = true)
     @Mapping(target = "id", source = "id")
     LeaveApplicationDTO toDtoId(LeaveApplication leaveApplication);
+
+    @Mapping(target = "days", ignore = true)
+    LeaveApplication toEntity(LeaveApplicationDTO dto);
+
+    @Named("partialUpdate")
+    @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
+    @Mapping(target = "days", ignore = true)
+    void partialUpdate(@MappingTarget LeaveApplication entity, LeaveApplicationDTO dto);
 }

--- a/src/main/webapp/app/entities/leave-application/update/leave-application-update.component.html
+++ b/src/main/webapp/app/entities/leave-application/update/leave-application-update.component.html
@@ -78,6 +78,11 @@
         </div>
 
         <div class="form-group">
+          <label class="form-control-label" jhiTranslate="leaveApplicationApp.leaveApplication.days" for="field_days">Days</label>
+          <input type="number" class="form-control" name="days" id="field_days" data-cy="days" formControlName="days" readonly="true" />
+        </div>
+
+        <div class="form-group">
           <label class="form-control-label" jhiTranslate="leaveApplicationApp.leaveApplication.appliedDate" for="field_appliedDate"
             >Applied Date</label
           >
@@ -124,19 +129,6 @@
               formControlName="updateDate"
               placeholder="YYYY-MM-DD HH:mm"
             />
-          </div>
-        </div>
-
-        <div class="form-group">
-          <label class="form-control-label" jhiTranslate="leaveApplicationApp.leaveApplication.days" for="field_days">Days</label>
-          <input type="number" class="form-control" name="days" id="field_days" data-cy="days" formControlName="days" />
-          <div *ngIf="editForm.get('days')!.invalid && (editForm.get('days')!.dirty || editForm.get('days')!.touched)">
-            <small class="form-text text-danger" *ngIf="editForm.get('days')?.errors?.required" jhiTranslate="entity.validation.required">
-              This field is required.
-            </small>
-            <small class="form-text text-danger" [hidden]="!editForm.get('days')?.errors?.number" jhiTranslate="entity.validation.number">
-              This field should be a number.
-            </small>
           </div>
         </div>
 

--- a/src/main/webapp/app/entities/leave-application/update/leave-application-update.component.html
+++ b/src/main/webapp/app/entities/leave-application/update/leave-application-update.component.html
@@ -31,6 +31,7 @@
               ngbDatepicker
               #startDateDp="ngbDatepicker"
               formControlName="startDate"
+              [(ngModel)]="startDate"
             />
             <span class="input-group-append">
               <button type="button" class="btn btn-secondary" (click)="startDateDp.toggle()">
@@ -61,6 +62,7 @@
               ngbDatepicker
               #endDateDp="ngbDatepicker"
               formControlName="endDate"
+              [(ngModel)]="endDate"
             />
             <span class="input-group-append">
               <button type="button" class="btn btn-secondary" (click)="endDateDp.toggle()"><fa-icon icon="calendar-alt"></fa-icon></button>
@@ -128,16 +130,16 @@
         </div>
 
         <div class="form-group">
-          <label class="form-control-label" jhiTranslate="leaveApplicationApp.leaveApplication.days" for="field_days">Days</label>
-          <input type="number" class="form-control" name="days" id="field_days" data-cy="days" formControlName="days" />
-          <div *ngIf="editForm.get('days')!.invalid && (editForm.get('days')!.dirty || editForm.get('days')!.touched)">
-            <small class="form-text text-danger" *ngIf="editForm.get('days')?.errors?.required" jhiTranslate="entity.validation.required">
-              This field is required.
-            </small>
-            <small class="form-text text-danger" [hidden]="!editForm.get('days')?.errors?.number" jhiTranslate="entity.validation.number">
-              This field should be a number.
-            </small>
-          </div>
+          <label
+            class="form-control-label"
+            [(ngModel)]="daysField"
+            jhiTranslate="leaveApplicationApp.leaveApplication.days"
+            for="field_days"
+            >Days</label
+          >
+          <span type="number" readonly="true" class="form-control" name="days" id="field_days" data-cy="days" formControlName="days">
+            {{ startDate && endDate ? endDate.diff(startDate, 'day') : 0 }}
+          </span>
         </div>
 
         <div class="form-group">

--- a/src/main/webapp/app/entities/leave-application/update/leave-application-update.component.html
+++ b/src/main/webapp/app/entities/leave-application/update/leave-application-update.component.html
@@ -31,7 +31,6 @@
               ngbDatepicker
               #startDateDp="ngbDatepicker"
               formControlName="startDate"
-              [(ngModel)]="startDate"
             />
             <span class="input-group-append">
               <button type="button" class="btn btn-secondary" (click)="startDateDp.toggle()">
@@ -62,7 +61,6 @@
               ngbDatepicker
               #endDateDp="ngbDatepicker"
               formControlName="endDate"
-              [(ngModel)]="endDate"
             />
             <span class="input-group-append">
               <button type="button" class="btn btn-secondary" (click)="endDateDp.toggle()"><fa-icon icon="calendar-alt"></fa-icon></button>
@@ -130,16 +128,16 @@
         </div>
 
         <div class="form-group">
-          <label
-            class="form-control-label"
-            [(ngModel)]="daysField"
-            jhiTranslate="leaveApplicationApp.leaveApplication.days"
-            for="field_days"
-            >Days</label
-          >
-          <span type="number" readonly="true" class="form-control" name="days" id="field_days" data-cy="days" formControlName="days">
-            {{ startDate && endDate ? endDate.diff(startDate, 'day') : 0 }}
-          </span>
+          <label class="form-control-label" jhiTranslate="leaveApplicationApp.leaveApplication.days" for="field_days">Days</label>
+          <input type="number" class="form-control" name="days" id="field_days" data-cy="days" formControlName="days" />
+          <div *ngIf="editForm.get('days')!.invalid && (editForm.get('days')!.dirty || editForm.get('days')!.touched)">
+            <small class="form-text text-danger" *ngIf="editForm.get('days')?.errors?.required" jhiTranslate="entity.validation.required">
+              This field is required.
+            </small>
+            <small class="form-text text-danger" [hidden]="!editForm.get('days')?.errors?.number" jhiTranslate="entity.validation.number">
+              This field should be a number.
+            </small>
+          </div>
         </div>
 
         <div class="form-group">

--- a/src/main/webapp/app/entities/leave-application/update/leave-application-update.component.ts
+++ b/src/main/webapp/app/entities/leave-application/update/leave-application-update.component.ts
@@ -27,9 +27,6 @@ export class LeaveApplicationUpdateComponent implements OnInit {
   leaveTypesSharedCollection: ILeaveType[] = [];
   leaveStatusesSharedCollection: ILeaveStatus[] = [];
   staffSharedCollection: IStaff[] = [];
-  daysField: any = 0;
-  startDate: any = [];
-  endDate: any = [];
 
   editForm = this.fb.group({
     id: [],
@@ -119,7 +116,7 @@ export class LeaveApplicationUpdateComponent implements OnInit {
       endDate: leaveApplication.endDate,
       appliedDate: leaveApplication.appliedDate ? leaveApplication.appliedDate.format(DATE_TIME_FORMAT) : null,
       updateDate: leaveApplication.updateDate ? leaveApplication.updateDate.format(DATE_TIME_FORMAT) : null,
-      days: leaveApplication.startDate && leaveApplication.endDate ? leaveApplication.startDate.diff(leaveApplication.endDate, 'day') : 0,
+      days: leaveApplication.days,
       deleted: leaveApplication.deleted,
       leaveType: leaveApplication.leaveType,
       leaveStatus: leaveApplication.leaveStatus,

--- a/src/main/webapp/app/entities/leave-application/update/leave-application-update.component.ts
+++ b/src/main/webapp/app/entities/leave-application/update/leave-application-update.component.ts
@@ -62,6 +62,19 @@ export class LeaveApplicationUpdateComponent implements OnInit {
 
       this.loadRelationshipsOptions();
     });
+
+    this.onChanges();
+  }
+
+  onChanges(): void {
+    this.editForm.get('startDate')?.valueChanges.subscribe(val => {
+      const endDate = this.editForm.get(['endDate'])!.value;
+      this.editForm.get(['days'])!.setValue(val && endDate ? +endDate.diff(val, 'day') + 1 : 0);
+    });
+    this.editForm.get('endDate')?.valueChanges.subscribe(val => {
+      const startDate = this.editForm.get(['startDate'])!.value;
+      this.editForm.get(['days'])!.setValue(startDate && val ? +val.diff(startDate, 'day') + 1 : 0);
+    });
   }
 
   previousState(): void {

--- a/src/main/webapp/app/entities/leave-application/update/leave-application-update.component.ts
+++ b/src/main/webapp/app/entities/leave-application/update/leave-application-update.component.ts
@@ -27,6 +27,9 @@ export class LeaveApplicationUpdateComponent implements OnInit {
   leaveTypesSharedCollection: ILeaveType[] = [];
   leaveStatusesSharedCollection: ILeaveStatus[] = [];
   staffSharedCollection: IStaff[] = [];
+  daysField: any = 0;
+  startDate: any = [];
+  endDate: any = [];
 
   editForm = this.fb.group({
     id: [],
@@ -116,7 +119,7 @@ export class LeaveApplicationUpdateComponent implements OnInit {
       endDate: leaveApplication.endDate,
       appliedDate: leaveApplication.appliedDate ? leaveApplication.appliedDate.format(DATE_TIME_FORMAT) : null,
       updateDate: leaveApplication.updateDate ? leaveApplication.updateDate.format(DATE_TIME_FORMAT) : null,
-      days: leaveApplication.days,
+      days: leaveApplication.startDate && leaveApplication.endDate ? leaveApplication.startDate.diff(leaveApplication.endDate, 'day') : 0,
       deleted: leaveApplication.deleted,
       leaveType: leaveApplication.leaveType,
       leaveStatus: leaveApplication.leaveStatus,

--- a/src/test/java/za/co/dearx/leave/web/rest/LeaveApplicationResourceIT.java
+++ b/src/test/java/za/co/dearx/leave/web/rest/LeaveApplicationResourceIT.java
@@ -11,6 +11,7 @@ import static za.co.dearx.leave.web.rest.TestUtil.sameNumber;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.Period;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
@@ -60,9 +61,9 @@ class LeaveApplicationResourceIT {
     private static final ZonedDateTime UPDATED_UPDATE_DATE = ZonedDateTime.now(ZoneId.systemDefault()).withNano(0);
     private static final ZonedDateTime SMALLER_UPDATE_DATE = ZonedDateTime.ofInstant(Instant.ofEpochMilli(-1L), ZoneOffset.UTC);
 
-    private static final BigDecimal DEFAULT_DAYS = new BigDecimal(1);
-    private static final BigDecimal UPDATED_DAYS = new BigDecimal(2);
-    private static final BigDecimal SMALLER_DAYS = new BigDecimal(1 - 1);
+    private static final BigDecimal DEFAULT_DAYS = BigDecimal.valueOf(Period.between(DEFAULT_START_DATE, DEFAULT_END_DATE).getDays());
+    private static final BigDecimal UPDATED_DAYS = BigDecimal.valueOf(Period.between(UPDATED_START_DATE, UPDATED_END_DATE).getDays());
+    private static final BigDecimal SMALLER_DAYS = BigDecimal.valueOf(Period.between(SMALLER_START_DATE, SMALLER_END_DATE).getDays());
 
     private static final Boolean DEFAULT_DELETED = false;
     private static final Boolean DELETED = true;

--- a/src/test/java/za/co/dearx/leave/web/rest/LeaveApplicationResourceIT.java
+++ b/src/test/java/za/co/dearx/leave/web/rest/LeaveApplicationResourceIT.java
@@ -11,7 +11,6 @@ import static za.co.dearx.leave.web.rest.TestUtil.sameNumber;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.LocalDate;
-import java.time.Period;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
@@ -61,9 +60,9 @@ class LeaveApplicationResourceIT {
     private static final ZonedDateTime UPDATED_UPDATE_DATE = ZonedDateTime.now(ZoneId.systemDefault()).withNano(0);
     private static final ZonedDateTime SMALLER_UPDATE_DATE = ZonedDateTime.ofInstant(Instant.ofEpochMilli(-1L), ZoneOffset.UTC);
 
-    private static final BigDecimal DEFAULT_DAYS = BigDecimal.valueOf(Period.between(DEFAULT_START_DATE, DEFAULT_END_DATE).getDays());
-    private static final BigDecimal UPDATED_DAYS = BigDecimal.valueOf(Period.between(UPDATED_START_DATE, UPDATED_END_DATE).getDays());
-    private static final BigDecimal SMALLER_DAYS = BigDecimal.valueOf(Period.between(SMALLER_START_DATE, SMALLER_END_DATE).getDays());
+    private static final BigDecimal DEFAULT_DAYS = new BigDecimal(1);
+    private static final BigDecimal UPDATED_DAYS = new BigDecimal(2);
+    private static final BigDecimal SMALLER_DAYS = new BigDecimal(1 - 1);
 
     private static final Boolean DEFAULT_DELETED = false;
     private static final Boolean DELETED = true;

--- a/src/test/java/za/co/dearx/leave/web/rest/LeaveApplicationResourceIT.java
+++ b/src/test/java/za/co/dearx/leave/web/rest/LeaveApplicationResourceIT.java
@@ -15,6 +15,7 @@ import java.time.Period;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicLong;
@@ -49,9 +50,9 @@ class LeaveApplicationResourceIT {
     private static final LocalDate UPDATED_START_DATE = LocalDate.now(ZoneId.systemDefault());
     private static final LocalDate SMALLER_START_DATE = LocalDate.ofEpochDay(-1L);
 
-    private static final LocalDate DEFAULT_END_DATE = LocalDate.ofEpochDay(0L);
-    private static final LocalDate UPDATED_END_DATE = LocalDate.now(ZoneId.systemDefault());
-    private static final LocalDate SMALLER_END_DATE = LocalDate.ofEpochDay(-1L);
+    private static final LocalDate DEFAULT_END_DATE = DEFAULT_START_DATE.plus(1, ChronoUnit.DAYS);
+    private static final LocalDate UPDATED_END_DATE = UPDATED_START_DATE.plus(2, ChronoUnit.DAYS);
+    private static final LocalDate SMALLER_END_DATE = SMALLER_START_DATE;
 
     private static final ZonedDateTime DEFAULT_APPLIED_DATE = ZonedDateTime.ofInstant(Instant.ofEpochMilli(0L), ZoneOffset.UTC);
     private static final ZonedDateTime UPDATED_APPLIED_DATE = ZonedDateTime.now(ZoneId.systemDefault()).withNano(0);
@@ -302,8 +303,8 @@ class LeaveApplicationResourceIT {
     @Transactional
     void checkDaysIsRequired() throws Exception {
         int databaseSizeBeforeTest = leaveApplicationRepository.findAll().size();
-        // set the field null
-        leaveApplication.setDays(null);
+        // This field cannot be set null directly, so we set either start or end date to null
+        leaveApplication.setStartDate(null);
 
         // Create the LeaveApplication, which fails.
         LeaveApplicationDTO leaveApplicationDTO = leaveApplicationMapper.toDto(leaveApplication);


### PR DESCRIPTION
The following changes were made:
1. On creating and updating a leave application the total number of leave days will be auto generated using the start and end date of the leave period. The field is also read only.
2. The backend system will calculate the total number of leave days based on the leave dates supplied. This will happen before saving the entity to the database.